### PR TITLE
fix: ensure parsing pretty printed json is working

### DIFF
--- a/src/main/kotlin/com/cjcrafter/openai/OpenAICallback.kt
+++ b/src/main/kotlin/com/cjcrafter/openai/OpenAICallback.kt
@@ -48,7 +48,7 @@ internal class OpenAICallback(
         response.body?.source()?.use { source ->
 
             while (!source.exhausted()) {
-                var jsonResponse = source.readUtf8Line()
+                var jsonResponse = source.readUtf8()
 
                 // Or data is separated by empty lines, ignore them. The final
                 // line is always "data: [DONE]", ignore it.


### PR DESCRIPTION
Always got this error when using the lib :

```com.google.gson.JsonSyntaxException: java.io.EOFException: End of input at line 1 column 2 path $.
	at com.google.gson.internal.Streams.parse(Streams.java:59)
	at com.google.gson.JsonParser.parseReader(JsonParser.java:102)
	at com.google.gson.JsonParser.parseReader(JsonParser.java:70)
	at com.google.gson.JsonParser.parseString(JsonParser.java:51)
	at com.cjcrafter.openai.OpenAICallback.handleStream(OpenAICallback.kt:66)
	at com.cjcrafter.openai.OpenAICallback.onResponse(OpenAICallback.kt:30)
	at com.cjcrafter.openai.OpenAI.createChatCompletion(OpenAI.kt:252)
```
related: https://github.com/CJCrafter/ChatGPT-Java-API/issues/25